### PR TITLE
Fix text going out of screen on narrow window dimensions 

### DIFF
--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -10,7 +10,6 @@ const Wrapper = styled(Row)`
   align-items: center;
   justify-content: center;
   text-align: center;
-  flex-direction: column;
 `
 
 const Title = styled.h1`


### PR DESCRIPTION
Hey there!

This issue is happening when the window is narrow horizontally (width is considerably greater than height) such as mobiles with the keyboard opened in portrait, or mobile in landscape.

![image](https://user-images.githubusercontent.com/5701162/34940253-18668ca4-f9ef-11e7-9644-d1f33ddc9bbb.png)
