### PR TITLE
Removed Copenhagen from the list of cities where Uber operates

### DIFF
--- a/src/data/uber.json
+++ b/src/data/uber.json
@@ -1961,10 +1961,6 @@
       "link": "/en-GB/cities/cluj/"
     },
     {
-      "name": "Copenhagen",
-      "link": "/en-GB/cities/copenhagen/"
-    },
-    {
       "name": "Croatian Coast",
       "link": "/en-GB/cities/split/"
     },


### PR DESCRIPTION
Uber has stopped operating in Copenhagen, but their city page is still up. They have (work) offices in the country, and they are probably trying to get back in, but they have been shut down since April 2017 with no forseeable coming back.
Sources:
- https://euobserver.com/nordic/137410
- https://www.reuters.com/article/us-uber-tech-denmark/uber-to-end-services-in-denmark-after-less-than-three-years-idUSKBN16Z10G
- https://www.theguardian.com/technology/2017/mar/28/uber-to-shut-down-denmark-operation-over-new-taxi-laws