### PR TITLE
group results by name before checking for duplicates

### DIFF
--- a/src/routes/search/index.js
+++ b/src/routes/search/index.js
@@ -87,7 +87,7 @@ class Search extends Component {
   }
 
   render({ city }, { cities, loaded }) {
-    if (loaded && cities.length <= 1) {
+    if (loaded && uniqBy(cities, 'name').length <= 1) {
       this.selectCity(city)
     }
 


### PR DESCRIPTION
Search results containing multiple services for a single city are incorrectly considered to contain multiple cities.