### PR TITLE
Add Paris fixed prices from airports

### DIFF
--- a/src/utils/edgeCases.js
+++ b/src/utils/edgeCases.js
@@ -16,6 +16,11 @@ const cases = [
       'Uber drivers only take payment by cash. If they think you\'ll pay by card then they\'ll cancel the ride',
     name: 'buenos aires',
   },
+  {
+    type: 'price',
+    message: 'A ride from Charles de Gaule Airport to Paris is legally set at 50-55€, and 30-35€ from Orly Airport. Beware of frauds.',
+    name: 'paris',
+  },
 ]
 
 export default city =>


### PR DESCRIPTION
Some taxis/Ubers/whatever can try to fraud by asking a high price for a ride from an airport to the city (see this [particularly damning example](https://www.youtube.com/watch?v=RxDtqFCKk8Q) where the driver asked for 250€).
Prices are legally set by the city ([source, in French](http://leparticulier.lefigaro.fr/jcms/p1_1598200/taxi-tc-compter-entre-30-et-55-entre-paris-et-l-aeroport)).