### PR TITLE
Home Route Responsiveness Improvements for issue #57

### DIFF
--- a/src/routes/home/elements.js
+++ b/src/routes/home/elements.js
@@ -41,11 +41,17 @@ export const Title = styled.h1`
 
   @media (max-width: 767px) {
     font-size: 50px;
+    margin-top: 10px;
   }
 
   @media (max-width: 360px) {
     font-size: 30px;
-    margin-top: 10px;
+    padding-bottom: 80px;
+  }
+
+  @media (max-height: 360px) {
+    font-size: 30px;
+    padding-bottom: 80px;
   }
 `
 export const Algolia = styled.img`
@@ -56,6 +62,15 @@ export const Algolia = styled.img`
   bottom: 30px;
   transform: translateX(-50%);
   cursor: pointer;
+
+  @media (max-height: 360px) {
+    bottom: 15px;
+  }
+
+  /** Simply no space to display this */
+  @media (max-height: 300px) {
+    display: none;
+  }
 `
 
 export const Input = styled.input`
@@ -85,6 +100,10 @@ export const Input = styled.input`
     font-size: 40px;
     height: 40px;
     margin-top: 20px;
+  }
+
+  @media (max-height: 360px) {
+    font-size: 30px;
   }
 
   @media (max-width: 360px) {

--- a/src/routes/home/elements.js
+++ b/src/routes/home/elements.js
@@ -46,7 +46,7 @@ export const Title = styled.h1`
 
   @media (max-width: 360px) {
     font-size: 30px;
-    padding-bottom: 80px;
+    margin-top: 10px;
   }
 
   @media (max-height: 360px) {

--- a/src/routes/home/elements.js
+++ b/src/routes/home/elements.js
@@ -68,7 +68,7 @@ export const Algolia = styled.img`
   }
 
   /** Simply no space to display this */
-  @media (max-height: 300px) {
+  @media (max-height: 200px) {
     display: none;
   }
 `

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -18,7 +18,7 @@ export default class Home extends Component {
     this.setState({ value: '' }, () => route(`search/${fixName(value)}`, true))
   }
 
-  render({ }, { value }) {
+  render({}, { value }) {
     return (
       <Wrapper>
         <LogoImg src={Logo} alt="Is There Uber In" height="150" />

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -18,7 +18,7 @@ export default class Home extends Component {
     this.setState({ value: '' }, () => route(`search/${fixName(value)}`, true))
   }
 
-  render({}, { value }) {
+  render({ }, { value }) {
     return (
       <Wrapper>
         <LogoImg src={Logo} alt="Is There Uber In" height="150" />


### PR DESCRIPTION
In response to issue #57 I improved the responsiveness on the home screen:

- [x] Added padding to the title to make space for the footer text to show when the keyboard is shown
- [x] Reduced font-size and margins for landscape mobile

Before - mobile profile:
![saghxqkp 1](https://user-images.githubusercontent.com/1227748/48985841-c0b83780-f10c-11e8-8c9b-36595f1dcc3a.jpg)

After - mobile profile:
![screenshot_2018-11-25-23-43-09](https://user-images.githubusercontent.com/1227748/48985850-e0e7f680-f10c-11e8-96b3-1d2b4535b641.jpg)

Before - mobile landscape without keyboard:
![screenshot_2018-11-25-23-44-14](https://user-images.githubusercontent.com/1227748/48985855-f0ffd600-f10c-11e8-8075-bbff25d450c6.jpg)

After - mobile landscape without keyboard:
![screenshot_2018-11-25-23-47-38](https://user-images.githubusercontent.com/1227748/48985860-fc530180-f10c-11e8-9a5c-8593895f2291.jpg)

Mobile landscape with keyboard - hides the footer text since it doesn't fit:
![screenshot_2018-11-25-23-10-47](https://user-images.githubusercontent.com/1227748/48985877-299faf80-f10d-11e8-9cdb-6c5e541dcc3f.jpg)

