### PR TITLE
Fix anchor css position on home

### DIFF
--- a/src/routes/home/elements.js
+++ b/src/routes/home/elements.js
@@ -73,6 +73,10 @@ export const Algolia = styled.img`
   }
 `
 
+export const AlgoliaLink = styled.a`
+  position: static;
+`
+
 export const Input = styled.input`
   border: none;
   border-bottom: 1px solid ${props => props.theme.secondary};

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -2,7 +2,7 @@ import { h, Component } from 'preact'
 import { route } from 'preact-router'
 import Logo from '../../assets/logo.svg'
 import AlgoliaLogo from '../../assets/algolia.svg'
-import { Wrapper, LogoImg, Title, Algolia, Input, Form } from './elements'
+import { Wrapper, LogoImg, Title, Algolia, AlgoliaLink, Input, Form } from './elements'
 import { fixNameB as fixName } from '../../utils/fixName'
 
 export default class Home extends Component {
@@ -18,7 +18,7 @@ export default class Home extends Component {
     this.setState({ value: '' }, () => route(`search/${fixName(value)}`, true))
   }
 
-  render({}, { value }) {
+  render({ }, { value }) {
     return (
       <Wrapper>
         <LogoImg src={Logo} alt="Is There Uber In" height="150" />
@@ -35,13 +35,13 @@ export default class Home extends Component {
           </Form>
           ?
         </Title>
-        <a
+        <AlgoliaLink
 	href="https://www.algolia.com"
 	target="_blank"
 	rel="noopener noreferrer"
         >
           <Algolia src={AlgoliaLogo} aria-label="Search by Algolia" />
-        </a>
+        </AlgoliaLink>
       </Wrapper>
     )
   }


### PR DESCRIPTION
Recent changes made in the [global.js](https://github.com/SaraVieira/uber-cities/blob/master/src/utils/global.js) to the global css for the anchor element causes the Algolia link to position itself incorrectly `relative`, thereby making it not visible on the home page anymore (check the live site currently: https://isthereuber.in/).

It's needs to have `position: static` on the home page due to its layout.

This PR fixes that issue without affecting other anchor elements in the app.